### PR TITLE
Ajustes nas regras de mudança de texto

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "content.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-	"build": "webpack --mode=production"
+    "build": "webpack --mode=production"
   },
   "repository": {
     "type": "git",

--- a/src/rules.js
+++ b/src/rules.js
@@ -6,9 +6,15 @@ export const RULES = [
     target: '$& a deuxxx'
   },
   {
+    nome: 'brnation',
+    descricao: '',
+    selector: /brasil(eir)?(a|o)?/gim,
+    target: 'NAÇÃO BRASILEIRA'
+  },
+  {
     nome: 'ursal',
     descricao: '',
-    selector: /brasil/gim,
+    selector: /(PSDB?|PTC?B?|PPS?L?|MDB|PSL|PDT|PCO|PCdoB|DEM|PSOL|PSB|PCB|PSC|PSTU|NOVO|PV|REDE|PRB?P?(OS)?(TB)?|PRB|PRP|PMN|PHS|SD|DC|AVANTE|PODE|PMB)/gm,
     target: 'URSAL'
-  }
+  },
 ];


### PR DESCRIPTION
Como mencionei na issue #19, inseri a regra que troca brasil para NAÇÃO BRASILEIRA (e brasileiro(a) também, pra não ficar NAÇÃO BRASILEIRAeiro, haha). 

Adicionei uma lista gigante de partidos para serem substituídos por URSAL, também. Menos o PATRIOTA, partido do verdadeiro mito, Daciolo!! Hahaha